### PR TITLE
doc cleanup and section 4 addition

### DIFF
--- a/cddl/media-types.cddl
+++ b/cddl/media-types.cddl
@@ -3,33 +3,33 @@ vlei-media-type =
   "application/acdc+json;profile=urn:vlei:ecr" /
   "application/acdc+json;profile=urn:vlei:ecr;charset=utf-16le" /
   "application/acdc+json;profile=urn:vlei:oor" /
-  "application/acdc+json;profile=urn:vlei:lar" /
+  "application/acdc+json;profile=urn:vlei:ecra" /
   "application/acdc+json;profile=urn:vlei:qvi" /
-  "application/acdc+json;profile=urn:vlei:vra" /
+  "application/acdc+json;profile=urn:vlei:oora" /
   "application/acdc+cbor;profile=urn:vlei:leid" /
   "application/acdc+cbor;profile=urn:vlei:leid;base64=true" /
   "application/acdc+cbor;profile=urn:vlei:ecr" /
   "application/acdc+cbor;profile=urn:vlei:ecr;base64=true" /
   "application/acdc+cbor;profile=urn:vlei:oor" /
   "application/acdc+cbor;profile=urn:vlei:oor;base64=true" /
-  "application/acdc+cbor;profile=urn:vlei:lar" /
-  "application/acdc+cbor;profile=urn:vlei:lar;base64=true" /
+  "application/acdc+cbor;profile=urn:vlei:ecra" /
+  "application/acdc+cbor;profile=urn:vlei:ecra;base64=true" /
   "application/acdc+cbor;profile=urn:vlei:qvi" /
   "application/acdc+cbor;profile=urn:vlei:qvi;base64=true" /
-  "application/acdc+cbor;profile=urn:vlei:vra" /
-  "application/acdc+cbor;profile=urn:vlei:vra;base64=true" /
+  "application/acdc+cbor;profile=urn:vlei:oora" /
+  "application/acdc+cbor;profile=urn:vlei:oora;base64=true" /
   "application/acdc+msgpk;profile=urn:vlei:leid" /
   "application/acdc+msgpk;profile=urn:vlei:leid;base64=true" /
   "application/acdc+msgpk;profile=urn:vlei:ecr" /
   "application/acdc+msgpk;profile=urn:vlei:ecr;base64=true" /
   "application/acdc+msgpk;profile=urn:vlei:oor" /
   "application/acdc+msgpk;profile=urn:vlei:oor;base64=true" /
-  "application/acdc+msgpk;profile=urn:vlei:lar" /
-  "application/acdc+msgpk;profile=urn:vlei:lar;base64=true" /
+  "application/acdc+msgpk;profile=urn:vlei:ecra" /
+  "application/acdc+msgpk;profile=urn:vlei:ecra;base64=true" /
   "application/acdc+msgpk;profile=urn:vlei:qvi" /
   "application/acdc+msgpk;profile=urn:vlei:qvi;base64=true" /
-  "application/acdc+msgpk;profile=urn:vlei:vra" /
-  "application/acdc+msgpk;profile=urn:vlei:vra;base64=true" /
+  "application/acdc+msgpk;profile=urn:vlei:oora" /
+  "application/acdc+msgpk;profile=urn:vlei:oora;base64=true" /
   "application/acdc+cesr;profile=urn:vlei:leid" /
   "application/acdc+cesr;profile=urn:vlei:leid;base64=true" /
   "application/acdc+cesr;profile=urn:vlei:leid;charset=utf-16le" /
@@ -37,12 +37,12 @@ vlei-media-type =
   "application/acdc+cesr;profile=urn:vlei:ecr;base64=true" /
   "application/acdc+cesr;profile=urn:vlei:oor" /
   "application/acdc+cesr;profile=urn:vlei:oor;base64=true" /
-  "application/acdc+cesr;profile=urn:vlei:lar" /
-  "application/acdc+cesr;profile=urn:vlei:lar;base64=true" /
+  "application/acdc+cesr;profile=urn:vlei:ecra" /
+  "application/acdc+cesr;profile=urn:vlei:ecra;base64=true" /
   "application/acdc+cesr;profile=urn:vlei:qvi" /
   "application/acdc+cesr;profile=urn:vlei:qvi;base64=true" /
-  "application/acdc+cesr;profile=urn:vlei:vra" /
-  "application/acdc+cesr;profile=urn:vlei:vra;base64=true" /
+  "application/acdc+cesr;profile=urn:vlei:oora" /
+  "application/acdc+cesr;profile=urn:vlei:oora;base64=true" /
   "application/said+cesr;profile=urn:vlei:leid" /
   "application/said+cesr;profile=urn:vlei:leid;base64=true" /
   "application/said+cesr;profile=urn:vlei:leid;charset=utf-16le" /
@@ -50,10 +50,10 @@ vlei-media-type =
   "application/said+cesr;profile=urn:vlei:ecr;base64=true" /
   "application/said+cesr;profile=urn:vlei:oor" /
   "application/said+cesr;profile=urn:vlei:oor;base64=true" /
-  "application/said+cesr;profile=urn:vlei:lar" /
-  "application/said+cesr;profile=urn:vlei:lar;base64=true" /
+  "application/said+cesr;profile=urn:vlei:ecra" /
+  "application/said+cesr;profile=urn:vlei:ecra;base64=true" /
   "application/said+cesr;profile=urn:vlei:qvi" /
   "application/said+cesr;profile=urn:vlei:qvi;base64=true" /
-  "application/said+cesr;profile=urn:vlei:vra" /
-  "application/said+cesr;profile=urn:vlei:vra;base64=true"
+  "application/said+cesr;profile=urn:vlei:oora" /
+  "application/said+cesr;profile=urn:vlei:oora;base64=true"
 

--- a/cddl/msg-wrapper.cddl
+++ b/cddl/msg-wrapper.cddl
@@ -4,33 +4,22 @@
 ; =====================================================================
 
 satp-message = {
-  ; --- Stage 1 ---
-  ? verifiedOriginatorEntityId: wrapped-vlei ; always "leid"
-  ? verifiedBeneficiaryEntityId: wrapped-vlei ; always "leid"
-  ? senderGatewayOwnerId: wrapped-vlei ; always "leid"
-  ? receiverGatewayOwnerId: wrapped-vlei ; always "leid"
+  ? verifiedOriginatorEntityId: wrapped-vlei
+  ? verifiedBeneficiaryEntityId: wrapped-vlei
+  ? senderGatewayOwnerId: wrapped-vlei
+  ? receiverGatewayOwnerId: wrapped-vlei
 
-  ? senderGatewayId: wrapped-vlei ; always "ecr"
-  ? recipientGatewayId: wrapped-vlei ; always "ecr"
-  ? senderGatewayNetworkId: wrapped-vlei ; always "ecr"
-  ? recipientGatewayNetworkId: wrapped-vlei ; always "ecr"
+  ? senderGatewayId: wrapped-vlei
+  ? recipientGatewayId: wrapped-vlei
+  ? senderGatewayNetworkId: wrapped-vlei
+  ? recipientGatewayNetworkId: wrapped-vlei
 
-  ? originatorPubkey: wrapped-key
-  ? beneficiaryPubkey: wrapped-key
-  ? senderGatewaySignaturePublicKey: wrapped-key
-  ? receiverGatewaySignaturePublicKey: wrapped-key
-  ? senderGatewayDeviceIdentityPubkey: wrapped-key
-  ? receiverGatewayDeviceIdentityPubkey: wrapped-key
-
-  ; --- Stage 2 ---
-  ? assetControllerCredential: wrapped-vlei ; can be "leid", "ecr" or "oor"
-  ? lockEvidenceIssuerCredential: wrapped-vlei ; can be "leid", "ecr" or "oor"
-  ? lockEvidenceVerificationKey: wrapped-key
-
-  ; --- Stage 3 ---
-  ? commitAuthorizingCredential: wrapped-vlei ; can be "leid", "ecr" or "oor"
-  ? commitVerificationKey: wrapped-key
-  ? postCommitSecureChannelKey: wrapped-key
+  ? originatorPubkey: wrapped-vlei / wrapped-key
+  ? beneficiaryPubkey: wrapped-vlei / wrapped-key
+  ? senderGatewaySignaturePublicKey: wrapped-vlei / wrapped-key
+  ? receiverGatewaySignaturePublicKey: wrapped-vlei / wrapped-key
+  ? senderGatewayDeviceIdentityPubkey: wrapped-vlei / wrapped-key
+  ? receiverGatewayDeviceIdentityPubkey: wrapped-vlei / wrapped-key
 }
 
 ; =====================================================================
@@ -43,7 +32,7 @@ wrapped-vlei = {
 }
 
 content-ref = non-empty<{ 
- ? mt: vlei-media-type ; TBA e.g., "application/acdc+json"
+ ? mt: vlei-media-type ; TBA 
  ? cf: uint ; TBA content format id
  ? cbt: bool ; payload contains CBOR tagged content in the TN() range if true, if false not cbor tagged and "mt" is required
  ? oid: tstr ; generated from content-format-id e.g., "1.3.6.1.4.1.37476.2.1.5"

--- a/examples/json/key-carrier1.jsonc
+++ b/examples/json/key-carrier1.jsonc
@@ -26,19 +26,6 @@
     "content": "application/pkix-cert",
     "encoding": "DER",
     "payload": "MIIB..." // base64 DER
-  },
-  "lockEvidenceVerificationKey": {
-    "content": "application/jwk+json",
-    "payload": "{ \"kty\": \"OKP\", \"crv\": \"Ed25519\", \"x\": \"...\" }"
-  },
-  "commitVerificationKey": {
-    "content": "application/cose;cose-type=cose-key",
-    "encoding": "base64",
-    "payload": "aEtNQ3BBLi4u"
-  },
-  "postCommitSecureChannelKey": {
-    "content": "application/jwk+json",
-    "payload": "{ \"kty\": \"EC\", \"crv\": \"P-384\", \"x\": \"...\", \"y\": \"...\" }"
   }
 }
 


### PR DESCRIPTION
Added section 4 on Identity, fixed tables and cddl to remove errant satp message info. started moving from "base64-" optional parameter to "encoding=" paramters which is more flexible.